### PR TITLE
Removed Event Binding

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -54,9 +54,6 @@ export default {
     if (!this.datepicker) {
       this.datepicker = new Datepicker(this.$el, this.config, this.l10n)
       this.popupItem = this.datepicker.calendarContainer
-      this.datepicker.set('onChange', (d, s) => {
-        this.date = s;
-      })
     }
   },
 


### PR DESCRIPTION
Not sure if this is due to my recent PR, or if its because I accidentally bumped flatpickr to 2.4.3 when pulling in the new vue-bulma-datepicker.
However, I encountered an issue along the lines of `node[i] is not a function` in flatpickr's `triggerEvent` function.  
Whilst getting to the bottom of it, I removed the `datepicker.set('onChange', ...)` hook from the components `mounted()` function.
This resolved the issue whilst maintaining proper reactivity